### PR TITLE
Because funcionality

### DIFF
--- a/fail.go
+++ b/fail.go
@@ -186,6 +186,17 @@ func (f *Fail) Unauthorized(m string) error {
 	return f
 }
 
+// Because uses the previous Fail's status and message.
+func (f *Fail) Because() {
+	if f.prev != nil {
+		switch f.prev.(type) {
+		case *Fail:
+			f.Message = f.prev.(*Fail).Message
+			f.Status = f.prev.(*Fail).Status
+		}
+	}
+}
+
 // Unauthorized is a convenience function to return an Unauthorized fail when there's
 // no Go error.
 func Unauthorized(m string) error {


### PR DESCRIPTION
# Because

Sets the current `fail`'s `message` & `status` to the previous errors to allow bubbling up of status code and message while retaining the previous errors information.